### PR TITLE
Parse ethernet frame

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,9 @@ RUN apt-get update && apt-get install -y \
 # Install Ruby gems
 RUN gem install ruby-pcap hexdump
 
-# Copy the Ruby files
-COPY udp/my_udp_server.rb .
-COPY udp/get_interface_index.rb .
+# Copy the Ruby files maintaining directory structure
+COPY udp/ ./udp/
+COPY managers/ ./managers/
 
 # Run the server
-CMD ["ruby", "my_udp_server.rb"] 
+CMD ["ruby", "udp/my_udp_server.rb"] 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ echo "Test packet" | nc -u localhost 5000
 Or use the provided Python script:
 
 ```bash
-python3 udp/send_udp.py
+python3 scripts/send_udp.py
 ```
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -41,13 +41,20 @@ The server will:
 2. Capture all packets on that interface
 3. Display:
    - Hex dump of packet contents
+   - UDP packet data
+   - Source IP address
+   - Source port
 
 ## Testing
 
 To send test packets to the server, you can use netcat:
 
 ```bash
+# Send a test packet (with newline)
 echo "Test packet" | nc -u localhost 5000
+
+# Send a test packet (without newline)
+echo -n "Test packet" | nc -u localhost 5000
 ```
 
 Or use the provided Python script:
@@ -55,6 +62,28 @@ Or use the provided Python script:
 ```bash
 python3 scripts/send_udp.py
 ```
+
+## Packet Structure
+
+The server parses the following packet layers:
+
+1. Ethernet Frame (14 bytes):
+   - Destination MAC (6 bytes)
+   - Source MAC (6 bytes)
+   - Ethertype (2 bytes)
+
+2. IPv4 Header (20+ bytes):
+   - Version and IHL
+   - Total Length
+   - Protocol
+   - Source IP Address
+   - Destination IP Address
+
+3. UDP Header (8 bytes):
+   - Source Port
+   - Destination Port
+   - Length
+   - Checksum
 
 ## Troubleshooting
 
@@ -78,10 +107,17 @@ docker logs udp-server-container
 docker exec udp-server-container ip addr
 ```
 
-4. Common issues:
+4. Check packet capture:
+
+```bash
+docker exec udp-server-container tcpdump -i eth0 -n udp port 5000
+```
+
+5. Common issues:
    - "No such device" error: The interface specified doesn't exist in the container
    - Permission denied: Container might not have the required capabilities
    - Network unreachable: Check if the Docker network is properly configured
+   - Packet truncation: Try using `-n` with echo to prevent newline addition
 
 ## Security Note
 

--- a/managers/ethernet_frame_manager.rb
+++ b/managers/ethernet_frame_manager.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'ip_packet_manager'
 class EthernetFrameManager
   attr_reader :bytes
 
@@ -7,8 +8,8 @@ class EthernetFrameManager
     @bytes = bytes
   end
 
-  def ip_packet
-    IPPacketManager.new(bytes)
+  def ip_packet_manager
+    IPPacketManager.new(bytes[14...-4])
   end
 
   def destination_mac

--- a/managers/ethernet_frame_manager.rb
+++ b/managers/ethernet_frame_manager.rb
@@ -7,6 +7,10 @@ class EthernetFrameManager
     @bytes = bytes
   end
 
+  def ip_packet
+    IPPacketManager.new(bytes)
+  end
+
   def destination_mac
     format_mac(bytes[0, 6])
   end

--- a/managers/ethernet_frame_manager.rb
+++ b/managers/ethernet_frame_manager.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'ip_packet_manager'
+
 class EthernetFrameManager
   attr_reader :bytes
 
@@ -9,7 +10,7 @@ class EthernetFrameManager
   end
 
   def ip_packet_manager
-    IPPacketManager.new(bytes[14...-4])
+    IPPacketManager.new(bytes[14..])
   end
 
   def destination_mac
@@ -21,19 +22,12 @@ class EthernetFrameManager
   end
 
   def ether_type
-    format_mac(bytes[12, 2])
+    (bytes[12].ord << 8 | bytes[13].ord).to_s(16).rjust(4, '0').upcase
   end
 
   private
 
   def format_mac(mac_bytes)
-    mac_bytes.map do |byte|
-      byte.to_s(16).rjust(2, '0')
-    end.join(':').upcase
-  end
-
-  def data
-    # Drop the first 14 bytes (MAC Header) and last 4 bytes (CRC Checksum)
-    IPPacket.new(bytes[14...-4])
+    mac_bytes.map { |byte| byte.to_s(16).rjust(2, '0') }.join(':').upcase
   end
 end

--- a/managers/ethernet_frame_manager.rb
+++ b/managers/ethernet_frame_manager.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class EthernetFrameManager
+  attr_reader :bytes
+
+  def initialize(bytes)
+    @bytes = bytes
+  end
+
+  def destination_mac
+    format_mac(bytes[0, 6])
+  end
+
+  def source_mac
+    format_mac(bytes[6, 6])
+  end
+
+  def ether_type
+    format_mac(bytes[12, 2])
+  end
+
+  private
+
+  def format_mac(mac_bytes)
+    mac_bytes.map do |byte|
+      byte.to_s(16).rjust(2, '0')
+    end.join(':').upcase
+  end
+
+  def data
+    # Drop the first 14 bytes (MAC Header) and last 4 bytes (CRC Checksum)
+    IPPacket.new(bytes[14...-4])
+  end
+end

--- a/managers/ip_packet_manager.rb
+++ b/managers/ip_packet_manager.rb
@@ -16,7 +16,7 @@ class IPPacketManager
   end
 
   def protocol
-    bytes[9]
+    bytes[9]  # Protocol field is at offset 9 in IPv4 header
   end
 
   def source_ip_address

--- a/managers/ip_packet_manager.rb
+++ b/managers/ip_packet_manager.rb
@@ -10,7 +10,8 @@ class IPPacketManager
   end
 
   def udp_datagram
-    UDPDatagramManager.new(bytes.drop(20))
+    header_length = ihl * 4  # IHL is in 32-bit words
+    UDPDatagramManager.new(bytes.bytes.drop(header_length))
   end
 
   def version

--- a/managers/ip_packet_manager.rb
+++ b/managers/ip_packet_manager.rb
@@ -15,6 +15,10 @@ class IPPacketManager
     bytes[0] & 0xF
   end
 
+  def protocol
+    bytes[9]
+  end
+
   def source_ip_address
     bytes[14, 4].join('.')
   end

--- a/managers/ip_packet_manager.rb
+++ b/managers/ip_packet_manager.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class IPPacketManager
+  attr_reader :bytes
+
+  def initialize(bytes)
+    @bytes = bytes
+  end
+
+  def version
+    bytes[0] >> 4
+  end
+
+  def ihl
+    bytes[0] & 0xF
+  end
+
+  def source_ip_address
+    bytes[14, 4].join('.')
+  end
+end

--- a/managers/ip_packet_manager.rb
+++ b/managers/ip_packet_manager.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'udp_datagram_manager'
+
 class IPPacketManager
   attr_reader :bytes
 
@@ -7,19 +9,29 @@ class IPPacketManager
     @bytes = bytes
   end
 
+  def udp_datagram
+    UDPDatagramManager.new(bytes.drop(20))
+  end
+
   def version
-    bytes[0] >> 4
+    bytes[0].ord >> 4
   end
 
   def ihl
-    bytes[0] & 0xF
+    bytes[0].ord & 0xF
   end
 
   def protocol
-    bytes[9]  # Protocol field is at offset 9 in IPv4 header
+    bytes[9].ord  # Protocol field is at offset 9 in IPv4 header
   end
 
   def source_ip_address
-    bytes[14, 4].join('.')
+    bytes[12, 4].bytes.join('.')
+  end
+
+  private
+
+  def word16(a, b)
+    (a << 8) | b
   end
 end

--- a/managers/udp_datagram_manager.rb
+++ b/managers/udp_datagram_manager.rb
@@ -1,31 +1,33 @@
 # frozen_string_literal: true
 
-class UDPDatagramMnager
+class UDPDatagramManager
+  attr_reader :bytes
+
   def initialize(bytes)
     @bytes = bytes
   end
 
   def source_port
-    word16(bytes[0], bytes[1])
+    word16(bytes[0].ord, bytes[1].ord)
   end
 
   def destination_port
-    word16(bytes[2], bytes[3])
+    word16(bytes[2].ord, bytes[3].ord)
   end
 
   def length
-    word16(bytes[4], bytes[5])
+    word16(bytes[4].ord, bytes[5].ord)
   end
 
   def checksum
-    word16(bytes[6], bytes[7])
+    word16(bytes[6].ord, bytes[7].ord)
   end
 
   def word16(a, b)
-    (a << 8) | b
+    (a << 8) | b  # Use bitwise OR to combine the bytes
   end
 
   def body
-    bytes[8, (length - 8)].pack('C*')
+     bytes[8, (length - 8)].pack('C*').force_encoding('UTF-8')
   end
 end

--- a/managers/udp_datagram_manager.rb
+++ b/managers/udp_datagram_manager.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class UDPDatagramMnager
+  def initialize(bytes)
+    @bytes = bytes
+  end
+
+  def source_port
+    word16(bytes[0], bytes[1])
+  end
+
+  def destination_port
+    word16(bytes[2], bytes[3])
+  end
+
+  def length
+    word16(bytes[4], bytes[5])
+  end
+
+  def checksum
+    word16(bytes[6], bytes[7])
+  end
+
+  def word16(a, b)
+    (a << 8) | b
+  end
+
+  def body
+    bytes[8, (length - 8)].pack('C*')
+  end
+end

--- a/managers/udp_datagram_manager.rb
+++ b/managers/udp_datagram_manager.rb
@@ -28,6 +28,6 @@ class UDPDatagramManager
   end
 
   def body
-     bytes[8, (length - 8)].pack('C*').force_encoding('UTF-8')
+     bytes[8, (length - 8)].pack('C*')
   end
 end

--- a/udp/my_udp_server.rb
+++ b/udp/my_udp_server.rb
@@ -5,7 +5,7 @@ require 'hexdump'
 require_relative 'get_interface_index'
 require_relative '../managers/ethernet_frame_manager'
 
-BUFFER_SIZE = 1024
+BUFFER_SIZE = 65535
 ETH_P_ALL = 0x0300
 SOCKADDR_LL_SIZE = 0x0014
 UDP_PROTOCOL = 0x11

--- a/udp/my_udp_server.rb
+++ b/udp/my_udp_server.rb
@@ -7,6 +7,7 @@ require_relative 'get_interface_index'
 BUFFER_SIZE = 1024
 ETH_P_ALL = 0x0300
 SOCKADDR_LL_SIZE = 0x0014
+UDP_PROTOCOL = 0x11
 
 def bind_socket(interface_name)
   socket, index = get_interface_index(interface_name)
@@ -34,6 +35,16 @@ def start_server
       puts "Packets received..."
       Hexdump.dump(data)
       puts "Packets processed..."
+
+      frame = EthernetFrameMnager.new(data)
+
+      next unless frame.ip_packet_manager.protocol == UDP_PROTOCOL &&
+        frame.ip_packet.udp_datagram.destination_port == 5000
+
+
+      puts "data: #{frame.ip_packet.udp_datagram.body.upcase}"
+      puts "source ip: #{frame.ip_packet.source_ip_address}"
+      puts "source port: #{frame.ip_packet.udp_datagram.source_port}"
     end
   rescue => e
     puts "Error: #{e.message}"

--- a/udp/my_udp_server.rb
+++ b/udp/my_udp_server.rb
@@ -3,6 +3,7 @@
 require 'pcap'
 require 'hexdump'
 require_relative 'get_interface_index'
+require_relative '../managers/ethernet_frame_manager'
 
 BUFFER_SIZE = 1024
 ETH_P_ALL = 0x0300

--- a/udp/my_udp_server.rb
+++ b/udp/my_udp_server.rb
@@ -33,19 +33,19 @@ def start_server
 
     loop do
       data = socket.recv(BUFFER_SIZE)
-      puts "Packets received..."
+      puts "\nPackets received..."
       Hexdump.dump(data)
-      puts "Packets processed..."
 
       frame = EthernetFrameManager.new(data)
+      protocol = frame.ip_packet_manager.protocol
+      puts "frame.ip_packet_manager.protocol: 0x#{protocol.ord.to_s(16).rjust(2, '0')}"
 
-      next unless frame.ip_packet_manager.protocol == UDP_PROTOCOL &&
+      next unless protocol.ord == UDP_PROTOCOL &&
         frame.ip_packet.udp_datagram.destination_port == 5000
 
-
-      puts "data: #{frame.ip_packet.udp_datagram.body.upcase}"
-      puts "source ip: #{frame.ip_packet.source_ip_address}"
-      puts "source port: #{frame.ip_packet.udp_datagram.source_port}"
+      puts "data: #{frame.ip_packet_manager.udp_datagram.body.upcase}"
+      puts "source ip: #{frame.ip_packet_manager.source_ip_address}"
+      puts "source port: #{frame.ip_packet_manager.udp_datagram.source_port}"
     end
   rescue => e
     puts "Error: #{e.message}"

--- a/udp/my_udp_server.rb
+++ b/udp/my_udp_server.rb
@@ -41,9 +41,9 @@ def start_server
       puts "frame.ip_packet_manager.protocol: 0x#{protocol.ord.to_s(16).rjust(2, '0')}"
 
       next unless protocol.ord == UDP_PROTOCOL &&
-        frame.ip_packet.udp_datagram.destination_port == 5000
+        frame.ip_packet_manager.udp_datagram.destination_port == 5000
 
-      puts "data: #{frame.ip_packet_manager.udp_datagram.body.upcase}"
+      puts "data: #{frame.ip_packet_manager.udp_datagram.body}"
       puts "source ip: #{frame.ip_packet_manager.source_ip_address}"
       puts "source port: #{frame.ip_packet_manager.udp_datagram.source_port}"
     end

--- a/udp/my_udp_server.rb
+++ b/udp/my_udp_server.rb
@@ -36,7 +36,7 @@ def start_server
       Hexdump.dump(data)
       puts "Packets processed..."
 
-      frame = EthernetFrameMnager.new(data)
+      frame = EthernetFrameManager.new(data)
 
       next unless frame.ip_packet_manager.protocol == UDP_PROTOCOL &&
         frame.ip_packet.udp_datagram.destination_port == 5000


### PR DESCRIPTION
This pull request introduces significant improvements to the UDP server, including enhanced packet parsing, better directory structure management, and updated documentation. The key changes involve the addition of modular classes for parsing Ethernet, IP, and UDP layers, updates to the server logic to utilize these classes, and enhancements to the README for clarity and usability.

### Modular Packet Parsing
* Added `EthernetFrameManager` to parse Ethernet frames, including destination MAC, source MAC, and EtherType. (`managers/ethernet_frame_manager.rb`)
* Added `IPPacketManager` to parse IPv4 headers, including version, IHL, protocol, source IP, and UDP datagrams. (`managers/ip_packet_manager.rb`)
* Added `UDPDatagramManager` to parse UDP headers, including source port, destination port, length, checksum, and body. (`managers/udp_datagram_manager.rb`)

### Server Logic Enhancements
* Updated `my_udp_server.rb` to use the new packet parsing classes, allowing the server to process Ethernet, IP, and UDP layers. Added logic to filter packets by protocol and destination port, and to display source IP, source port, and UDP payload. (`udp/my_udp_server.rb`)
* Increased `BUFFER_SIZE` from 1024 to 65535 to handle larger packets. (`udp/my_udp_server.rb`)

### Improved Directory Structure
* Updated the `Dockerfile` to copy files while maintaining directory structure. Adjusted the `CMD` to reflect the new file paths. (`Dockerfile`)

### Documentation Updates
* Enhanced the README to include details about packet structure (Ethernet, IP, UDP), new test commands for sending packets, and troubleshooting steps for packet capture. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R44-R87) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L81-R120)